### PR TITLE
Fixed issue where LatestImage flag wouldn't get the latest Image.

### DIFF
--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -289,8 +289,7 @@
             if (-not $ParentVhd) {
 
                 if ($LatestImage) {
-                    $images = Get-DcnImage -Database $db
-                    $result = $images[-1] | Sort-Object CreatedOn
+                    $result = Get-DcnImage -Database $db | Sort-Object -Descending CreatedOn | Select-Object -First 1
                 }
 
                 # Check the results


### PR DESCRIPTION
Hi @sanderstad,

Could I get this fix merged into Development and Master as soon as possible, please? Currently unable to clone new images if there are multiple images for a given database.