### PR TITLE
Fix new clone (volume not found) from remote, when no destination folder is specified

### DIFF
--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -236,7 +236,7 @@
 
         # Check destination
         if (-not $Destination) {
-            $Destination = Join-PSFPath -Path $server.DefaultFile -Child "clone"
+            $Destination = [System.IO.Path]::Combine($server.DefaultFile, "clone")
         }
         else {
             # If the destination is a network path


### PR DESCRIPTION
If you use then New-DcnClone from remote machine, Join-PSFPath not work when $server.DefaultFile contains volume that non exist on local PC.

I have convert Join-PSFPath to [System.IO.Path]::Combine when New-DcnClone initialize the destination folder.