### PR TITLE
use database as param for invoke-dbaquery

### DIFF
--- a/functions/image/New-DcnImage.ps1
+++ b/functions/image/New-DcnImage.ps1
@@ -651,7 +651,7 @@
                         $params = @{
                             SqlInstance     = $DestinationSqlInstance
                             SqlCredential   = $DestinationSqlCredential
-                            DatabaseName    = $tempDbName
+                            Database        = $tempDbName
                             Query           = $ExecuteSQLCommand
                             EnableException = $EnableException
                         }
@@ -670,7 +670,7 @@
                         $params = @{
                             SqlInstance     = $DestinationSqlInstance
                             SqlCredential   = $DestinationSqlCredential
-                            DatabaseName    = $tempDbName
+                            Database        = $tempDbName
                             File            = $ExecuteSQLFile
                             EnableException = $EnableException
                         }


### PR DESCRIPTION
Fixes #170 - Invoke-DbaQuery only accepts `Database` as a param and not `DatabaseName`