### PR TITLE
Fix for Issue 176

### DIFF
--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -97,6 +97,8 @@
         [PSCredential]$Credential,
         [parameter(Mandatory = $true, ParameterSetName = "ByParent")]
         [string]$ParentVhd,
+        [parameter(Mandatory = $true, ParameterSetName = "ByImage")]
+        [int]$ImageId,
         [string]$Destination,
         [string]$CloneName,
         [parameter(Mandatory = $true, ParameterSetName = "ByLatest")]
@@ -131,6 +133,11 @@
             Stop-PSFFunction -Message "Please enter a destination when using -SkipDatabaseMount" -Continue
         }
 
+        if ($ImageId) {
+            $result = Get-DcnImage | Where-Object ImageID -eq $ImageID
+            $ParentVhd = $result.ImageLocation
+        }
+
         # Check the available images
         if (-not $ParentVhd) {
             $images = Get-DcnImage
@@ -138,6 +145,9 @@
             if ($Database -notin $images.DatabaseName) {
                 Stop-PSFFunction -Message "There is no image for database '$Database'" -Continue
             }
+        } else {
+            $result = Get-DcnImage | Where-Object ImageLocation -eq $ParentVhd
+            $Database = $result.DatabaseName;
         }
 
         # Get the information store

--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -30,6 +30,9 @@
     .PARAMETER ParentVhd
         Points to the parent VHD to create the clone from
 
+    .PARAMETER ImageId
+        Image ID to create the clone from
+
     .PARAMETER Destination
         Destination directory to save the clone to
 


### PR DESCRIPTION
Closes #176 
Closes #146
Please let me know if there's any thoughts here. It is my understanding that $ParentVHD and ($Database, $LatestImage) are mutually exclusive. However, the codebase requires $Database to be set, so when using $ParentVHD it wont actually work (since there are no databases set). This fix basically looks up the database name if supplied a ParentVHD

I also added a new parameter, $ImageID, to be able to create a clone based on an image ID.

Also, I'm not sure what utility $LatestImage has. The code looks like this:

```
 foreach ($db in $Database) {

            if (-not $ParentVhd) {

                if ($LatestImage) {
                    $result = Get-DcnImage -Database $db | Sort-Object -Descending CreatedOn | Select-Object -First 1
                }

                # Check the results
                if ($null -eq $result) {
                    Stop-PSFFunction -Message "No image could be found for database $db" -Target $pdcSqlInstance -Continue
                }
                else {
                    $ParentVhd = $result.ImageLocation
                }
            }

```

$LatestImage seems to be required, otherwise $result is always unset. Is there a purpose for this? I propose it gets removed.