### PR TITLE
Adding 2022 to supported windows version .

### DIFF
--- a/functions/support/Test-DcnModule.ps1
+++ b/functions/support/Test-DcnModule.ps1
@@ -108,7 +108,10 @@ function Test-DcnModule {
                 'Microsoft Windows Server 2016 Datacenter',
                 'Microsoft Windows Server 2019 Standard',
                 'Microsoft Windows Server 2019 Enterprise',
-                'Microsoft Windows Server 2019 Datacenter'
+                'Microsoft Windows Server 2019 Datacenter',
+                'Microsoft Windows Server 2022 Standard',
+                'Microsoft Windows Server 2022 Enterprise',
+                'Microsoft Windows Server 2022 Datacenter'
             )
 
             # Get the OS details


### PR DESCRIPTION
We migrated to Windows 2022 for our Image build server and started getting the unsupported windows version warning so added the 2022 versions.