### PR TITLE
New-DcnClone: Set actual image size when using backup file source

### DIFF
--- a/functions/image/New-DcnImage.ps1
+++ b/functions/image/New-DcnImage.ps1
@@ -653,6 +653,11 @@
                     if (-not $lastFullBackup.Start) {
                         $lastFullBackup.Start = $global:dcnBackupInformation.Start
                     }
+
+                    # If no size set yet, get from restored backup info
+                    if ($dbSizeMB -eq 1) {
+                        $dbSizeMB =  $global:dcnBackupInformation.TotalSize
+                    }
                 }
                 catch {
                     Stop-PSFFunction -Message "Couldn't restore database $db as $tempDbName on $DestinationSqlInstance.`n$($_)" -Target $restore -ErrorRecord $_ -Continue


### PR DESCRIPTION
Fixes #172. 

May want to wait until https://github.com/dataplat/dbatools/pull/8330 is landed though, to make sure the proper size is getting recorded.