### PR TITLE
New-DcnClone: fix error using empty var

### DIFF
--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -464,7 +464,7 @@
                     }
                 }
                 catch {
-                    Stop-PSFFunction -Message "Couldn't mount vhd $vhdPath" -ErrorRecord $_ -Target $disk -Continue
+                    Stop-PSFFunction -Message "Couldn't mount vhd $clonePath" -ErrorRecord $_ -Target $disk -Continue
                 }
             }
 


### PR DESCRIPTION
The error message is referencing a null variable, use $clonePath instead.