### PR TITLE
Add Microsoft Windows 10 Pro Education to supported version

### DIFF
--- a/functions/support/Test-DcnModule.ps1
+++ b/functions/support/Test-DcnModule.ps1
@@ -20,6 +20,7 @@ function Test-DcnModule {
 
         Windows version should be in
             - 'Microsoft Windows 10 Pro',
+            - 'Microsoft Windows 10 Pro Education',
             - 'Microsoft Windows 10 Enterprise',
             - 'Microsoft Windows 10 Education',
             - 'Microsoft Windows Server 2008 R2 Standard',
@@ -97,6 +98,7 @@ function Test-DcnModule {
         if ($WindowsVersion) {
             $supportedVersions = @(
                 'Microsoft Windows 10 Pro',
+                'Microsoft Windows 10 Pro Education',
                 'Microsoft Windows 10 Enterprise',
                 'Microsoft Windows 10 Education',
                 'Microsoft Windows 11 Pro Insider Preview',


### PR DESCRIPTION
Windows 10 Pro - once hybrid-joined or azure-joined gets changed to 'Microsoft Windows 10 Pro Education'

![image](https://user-images.githubusercontent.com/1964381/191109743-056d672f-a1cd-4d22-bc1f-64c1984646c2.png)
